### PR TITLE
Fix multi-monitor crop generation and Plasma assignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,3 +47,26 @@ install(FILES assets/metainfo.xml
 install(FILES assets/wallpaper_splitter.desktop
     DESTINATION ${CMAKE_INSTALL_DATADIR}/applications
     RENAME io.github.l0drex.wallpaper_splitter.desktop)
+
+include(CTest)
+if(BUILD_TESTING)
+    find_package(Qt6 REQUIRED COMPONENTS Test)
+
+    qt_add_executable(splitimage_test
+            tests/splitimage_test.cpp
+            src/wallpapersplitter.cpp
+            src/wallpapersplitter.ui
+            src/screensitem.cpp
+            src/graphicsview.cpp)
+    target_include_directories(splitimage_test PRIVATE src)
+    target_link_libraries(splitimage_test PRIVATE
+            Qt6::Core
+            Qt6::DBus
+            Qt6::Gui
+            Qt6::Test
+            Qt6::Widgets
+            KF6::ConfigWidgets)
+    add_test(NAME splitimage_test COMMAND splitimage_test)
+    set_tests_properties(splitimage_test PROPERTIES
+            ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 find_package(Qt6 REQUIRED COMPONENTS
         Core
+        DBus
         Gui
         Widgets)
 
@@ -16,19 +17,19 @@ qt_standard_project_setup()
 
 find_package(KF6ConfigWidgets)
 
-qt_add_executable(wallpaper_splitter 
-        src/main.cpp 
-        src/wallpapersplitter.cpp 
-        src/wallpapersplitter.ui 
-        src/screensitem.cpp 
-        src/graphicsview.cpp 
+qt_add_executable(wallpaper_splitter
+        src/main.cpp
+        src/wallpapersplitter.cpp
+        src/wallpapersplitter.ui
+        src/screensitem.cpp
+        src/graphicsview.cpp
 )
 
 target_link_libraries(wallpaper_splitter PRIVATE
         Qt6::Core
+        Qt6::DBus
         Qt6::Gui
         Qt6::Widgets
-        Qt::DBus
         KF6::ConfigWidgets
 )
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,8 @@ int main(int argc, char *argv[]) {
         if (path.isEmpty()) {
             path = imageFile->absolutePath() + '/' + imageFile->baseName() + "_split";
         }
-        filePaths = WallpaperSplitter::splitImage(*image, path, topLeft, bottomRight);
+        filePaths = WallpaperSplitter::splitImage(
+                *image, path, topLeft, bottomRight, imageFile->completeBaseName());
 
         std::for_each(filePaths.begin(), filePaths.end(), [&](const QString& item){
             std::cout << item.toStdString() << std::endl;

--- a/src/screensitem.cpp
+++ b/src/screensitem.cpp
@@ -12,10 +12,6 @@
 #include <QGraphicsView>
 #include "screensitem.h"
 
-bool ScreenComparator(const QScreen *a, const QScreen *b) {
-    return a->geometry().x() < b->geometry().x();
-}
-
 ScreensItem::ScreensItem(QGraphicsItem *parent) : QGraphicsItemGroup(parent) {
     addScreens();
 
@@ -34,13 +30,20 @@ ScreensItem::ScreensItem(QGraphicsItem *parent) : QGraphicsItemGroup(parent) {
 
 void ScreensItem::addScreens() {
     auto screens = QApplication::screens();
+
+    // Keep Qt's screen order consistent with splitImage() and applyWallpaper().
+    // Wallpaper assignment itself uses virtual-desktop geometry because Plasma
+    // may assign different numeric screen indices to the same displays.
+    for (int index = 0; index < screens.size(); ++index) {
+        const QScreen *screen = screens.at(index);
+        qDebug() << "Qt screen" << index << screen->name()
+                 << screen->geometry() << screen->model();
+    }
+
     // get the currently used color scheme
     const auto colorScheme = KColorScheme();
     const auto pen = QPen(colorScheme.foreground(KColorScheme::ForegroundRole::ActiveText), 10);
 
-    // I don't fully understand why this is necessary
-    // most likely this will fail in different configs
-    std::sort(screens.begin(), screens.end(), ScreenComparator);
     // draw a rectangle for every screen
     std::for_each(screens.begin(), screens.end(), [&](const QScreen* screen){
         const auto rect = new QGraphicsRectItem();

--- a/src/wallpapersplitter.cpp
+++ b/src/wallpapersplitter.cpp
@@ -11,6 +11,8 @@
 #include <QScreen>
 #include <QDBusMessage>
 #include <QDBusConnection>
+#include <QCryptographicHash>
+#include <QJsonDocument>
 #include <QPushButton>
 #include "wallpapersplitter.h"
 #include "ui_wallpapersplitter.h"
@@ -68,7 +70,8 @@ void WallpaperSplitter::selectImage() {
 /**
  * Splits the selected image and returns a list to all paths where the images were saved.
  */
-QStringList WallpaperSplitter::splitImage(const QImage &image, const QList<QRect> &screens, const QString &path) {
+QStringList WallpaperSplitter::splitImage(const QImage &image, const QList<QRect> &screens,
+                                          const QString &path, const QString &outputBaseName) {
     if (screens.isEmpty()) {
         qFatal("No area to cut out provided!");
     }
@@ -76,25 +79,59 @@ QStringList WallpaperSplitter::splitImage(const QImage &image, const QList<QRect
         qFatal("Image could not be loaded");
     }
 
+    QRect cropBounds;
+    for (const QRect &screen : screens) {
+        cropBounds = cropBounds.isNull() ? screen : cropBounds.united(screen);
+    }
+    if (cropBounds.width() > image.width() || cropBounds.height() > image.height()) {
+        qFatal("Combined crop area is larger than the source image");
+    }
+
+    QPoint correction;
+    if (cropBounds.left() < image.rect().left()) {
+        correction.setX(image.rect().left() - cropBounds.left());
+    } else if (cropBounds.right() > image.rect().right()) {
+        correction.setX(image.rect().right() - cropBounds.right());
+    }
+    if (cropBounds.top() < image.rect().top()) {
+        correction.setY(image.rect().top() - cropBounds.top());
+    } else if (cropBounds.bottom() > image.rect().bottom()) {
+        correction.setY(image.rect().bottom() - cropBounds.bottom());
+    }
+    if (!correction.isNull()) {
+        qWarning() << "Moving crop layout by" << correction
+                   << "to fit source" << image.rect();
+    }
+
+    const QString safeBaseName = QFileInfo(outputBaseName).completeBaseName();
+
     QImage wallpaper;
     QString fileName;
     QStringList paths{};
-    QDir().mkdir(path);
+    QDir().mkpath(path);
     int index = 0;
 
-    std::for_each(screens.begin(), screens.end(), [&](const QRect screen){
-        if (!image.rect().contains(screen.topLeft())) {
-            qWarning("Image does not contain the top left corner of the provided rectangle!");
-        }
-        if (!image.rect().contains(screen.bottomRight())) {
-            qWarning("Image does not contain the bottom right position of the provided rectangle!");
+    std::for_each(screens.begin(), screens.end(), [&](QRect screen){
+        screen.translate(correction);
+        qDebug() << "Cropping" << screen << "from source" << image.rect();
+        if (!image.rect().contains(screen)) {
+            qFatal("Crop rectangle is outside the source image");
         }
 
         // copy a rectangle with size and position of the screen
         wallpaper = image.copy(screen);
+        qDebug() << "Generated crop" << index << wallpaper.size();
 
-        // images are saved as 0.png 1.png etc
-        fileName = path + '/' + QString::number(index) + ".png";
+        const QByteArrayView pixels(
+                reinterpret_cast<const char *>(wallpaper.constBits()),
+                wallpaper.sizeInBytes());
+        const QString digest = QString::fromLatin1(
+                QCryptographicHash::hash(pixels, QCryptographicHash::Sha256)
+                        .toHex().left(16));
+        // Keep all output in the selected directory. The crop-content digest
+        // makes Plasma reload changed pixels even if the source name is reused.
+        fileName = path + '/' + safeBaseName + '-'
+                + QString::number(index + 1) + '-' + digest + ".png";
         paths.append(fileName);
 
         // if this returns false, the save failed and the assertion fails
@@ -106,7 +143,9 @@ QStringList WallpaperSplitter::splitImage(const QImage &image, const QList<QRect
     return paths;
 }
 
-QStringList WallpaperSplitter::splitImage(const QImage &image, const QString &path, const QPoint topLeft, const QPoint bottomRight) {
+QStringList WallpaperSplitter::splitImage(const QImage &image, const QString &path,
+                                          const QPoint topLeft, const QPoint bottomRight,
+                                          const QString &outputBaseName) {
     QList<QRect> screenGeometries{};
     const auto screens = QApplication::screens();
     std::for_each(screens.begin(), screens.end(), [&](const QScreen* screen){
@@ -121,7 +160,7 @@ QStringList WallpaperSplitter::splitImage(const QImage &image, const QString &pa
         screenGeometries.append(geometry);
     });
 
-    return splitImage(image, screenGeometries, path);
+    return splitImage(image, screenGeometries, path, outputBaseName);
 }
 
 QStringList WallpaperSplitter::splitImage() {
@@ -145,7 +184,8 @@ QStringList WallpaperSplitter::splitImage() {
     }
 
     unsetCursor();
-    return WallpaperSplitter::splitImage(*wallpaper, screens, path);
+    return WallpaperSplitter::splitImage(
+            *wallpaper, screens, path, imageFile->completeBaseName());
 }
 
 /**
@@ -155,34 +195,71 @@ void WallpaperSplitter::applyWallpaper() {
     auto paths = splitImage();
     assert(!paths.isEmpty());
 
-    // apply the wallpapers via a dbus call
+    const auto screens = QApplication::screens();
+    assert(paths.size() == screens.size());
+
+    // Qt and Plasma can assign different numeric indices to the same physical
+    // screen. Pass each crop's virtual-desktop geometry so Plasma can match it
+    // to the containment's screenGeometry() without relying on index order.
+    QVariantList crops;
+    for (int index = 0; index < paths.size(); ++index) {
+        const QRect geometry = screens.at(index)->geometry();
+        crops.append(QVariantMap{
+                {"path", paths.at(index)},
+                {"x", geometry.x()},
+                {"y", geometry.y()},
+                {"width", geometry.width()},
+                {"height", geometry.height()}
+        });
+    }
+    const QString cropArray = QString::fromUtf8(
+            QJsonDocument::fromVariant(crops).toJson(QJsonDocument::Compact));
+    const QString script = QStringLiteral(R"(
+const crops = %1;
+function sameGeometry(crop, geometry) {
+    return crop.x === geometry.x && crop.y === geometry.y
+        && crop.width === geometry.width && crop.height === geometry.height;
+}
+function describeGeometry(geometry) {
+    return geometry.x + ',' + geometry.y + ' '
+        + geometry.width + 'x' + geometry.height;
+}
+for (const desktop of desktopsForActivity(currentActivity())) {
+    if (desktop.screen < 0) {
+        print('Skipping desktop ' + desktop.id + ' screen=' + desktop.screen);
+        continue;
+    }
+
+    const geometry = screenGeometry(desktop.screen);
+    const crop = crops.find(candidate => sameGeometry(candidate, geometry));
+    if (crop === undefined) {
+        print('No crop for desktop ' + desktop.id + ' screen=' + desktop.screen
+              + ' geometry=' + describeGeometry(geometry));
+        continue;
+    }
+
+    print('Desktop ' + desktop.id + ' screen=' + desktop.screen
+          + ' geometry=' + describeGeometry(geometry) + ' path=' + crop.path);
+    desktop.wallpaperPlugin = 'org.kde.image';
+    desktop.currentConfigGroup = ['Wallpaper', 'org.kde.image', 'General'];
+    desktop.writeConfig('Image', crop.path);
+}
+)").arg(cropArray);
+
     auto message = QDBusMessage::createMethodCall(
             "org.kde.plasmashell",
             "/PlasmaShell", "org.kde.PlasmaShell",
-            "setWallpaper");
+            "evaluateScript");
+    message.setArguments(QVariantList() << script);
 
-    for (int i = 0; i < paths.size(); i++) {
-        QVariantList arguments;
-
-        // wallpaper plugin
-        arguments << QVariant(QString("org.kde.image"));
-
-        // parameters
-        QVariantMap params;
-        params.insert(QString("Image"), QVariant(paths.first()));
-        arguments << params;
-
-        // screenNum
-        arguments << QVariant((uint) i);
-
-        message.setArguments(arguments);
-
-        qDebug() << "Applying image" << paths.join(", ");
-        auto reply = QDBusConnection::sessionBus().call(message);
-        if(reply.type() == QDBusMessage::ErrorMessage) {
-            qCritical() << "Something went wrong.";
-            qCritical() << reply.errorMessage();
-        }
+    qDebug() << "Applying crops by virtual-desktop geometry:" << crops;
+    const auto reply = QDBusConnection::sessionBus().call(message);
+    if(reply.type() == QDBusMessage::ErrorMessage) {
+        qCritical() << "Something went wrong.";
+        qCritical() << reply.errorMessage();
+    } else if (!reply.arguments().isEmpty()) {
+        qDebug().noquote() << "Plasma assignment:\n"
+                           << reply.arguments().constFirst().toString();
     }
 
     QApplication::quit();
@@ -252,7 +329,11 @@ void WallpaperSplitter::addImage(QImage &image) {
         screenGroup->setPos(imageItem->scenePos());
     }
 
-    screenGroup->setPos(imageItem->boundingRect().center());
+    // Screen rectangles use virtual-desktop coordinates and may have a non-zero
+    // or negative origin. Position the group's bounding-rectangle center on the
+    // image center instead of adding the image center as an offset.
+    screenGroup->setPos(imageItem->boundingRect().center()
+                        - screenGroup->boundingRect().center());
 
     scaleView();
 }

--- a/src/wallpapersplitter.h
+++ b/src/wallpapersplitter.h
@@ -21,8 +21,12 @@ Q_OBJECT
 public:
     explicit WallpaperSplitter(QWidget *parent = nullptr);
     ~WallpaperSplitter() override;
-    static QStringList splitImage(const QImage &image, const QString &path, QPoint topLeft = {0, 0}, QPoint bottomRight = {0, 0});
-    static QStringList splitImage(const QImage &image, const QList<QRect> &screens, const QString &path);
+    static QStringList splitImage(const QImage &image, const QString &path,
+                                  QPoint topLeft = {0, 0}, QPoint bottomRight = {0, 0},
+                                  const QString &outputBaseName = "wallpaper");
+    static QStringList splitImage(const QImage &image, const QList<QRect> &screens,
+                                  const QString &path,
+                                  const QString &outputBaseName = "wallpaper");
     void addImage(QImage &image);
     void addImage(const QUrl &url);
 

--- a/tests/splitimage_test.cpp
+++ b/tests/splitimage_test.cpp
@@ -1,0 +1,116 @@
+#include <QColor>
+#include <QDir>
+#include <QImage>
+#include <QTemporaryDir>
+#include <QtTest>
+
+#include "wallpapersplitter.h"
+
+class SplitImageTest : public QObject {
+    Q_OBJECT
+
+private slots:
+    void preservesRectangleOrderAndPixels();
+    void changesPathsWhenCropContentChanges();
+    void movesTranslatedLayoutInsideSource();
+};
+
+void SplitImageTest::preservesRectangleOrderAndPixels() {
+    QImage source(30, 10, QImage::Format_RGB32);
+    source.fill(Qt::black);
+    for (int x = 0; x < 10; ++x) {
+        for (int y = 0; y < source.height(); ++y) {
+            source.setPixelColor(x, y, Qt::red);
+            source.setPixelColor(x + 10, y, Qt::green);
+            source.setPixelColor(x + 20, y, Qt::blue);
+        }
+    }
+
+    QTemporaryDir outputDirectory;
+    QVERIFY(outputDirectory.isValid());
+
+    // Deliberately request middle, left, right to prove output order follows
+    // the supplied screen list rather than geometry sorting.
+    const QList<QRect> screens{
+            QRect(10, 0, 10, 10),
+            QRect(0, 0, 10, 10),
+            QRect(20, 0, 10, 10),
+    };
+    const QStringList paths = WallpaperSplitter::splitImage(
+            source, screens, outputDirectory.path(), "example.image.jpg");
+
+    QCOMPARE(paths.size(), 3);
+    const QList<QColor> expected{Qt::green, Qt::red, Qt::blue};
+    for (int index = 0; index < paths.size(); ++index) {
+        const QString fileName = QFileInfo(paths.at(index)).fileName();
+        QVERIFY(QRegularExpression(
+                QStringLiteral("^example\\.image-%1-[0-9a-f]{16}\\.png$")
+                        .arg(index + 1)).match(fileName).hasMatch());
+        QCOMPARE(QFileInfo(paths.at(index)).absolutePath(), outputDirectory.path());
+        const QImage crop(paths.at(index));
+        QCOMPARE(crop.size(), QSize(10, 10));
+        QCOMPARE(crop.pixelColor(5, 5), expected.at(index));
+    }
+}
+
+void SplitImageTest::changesPathsWhenCropContentChanges() {
+    QImage firstSource(20, 10, QImage::Format_RGB32);
+    firstSource.fill(Qt::red);
+    QImage secondSource(20, 10, QImage::Format_RGB32);
+    secondSource.fill(Qt::blue);
+
+    QTemporaryDir outputDirectory;
+    QVERIFY(outputDirectory.isValid());
+    const QList<QRect> screens{QRect(0, 0, 10, 10), QRect(10, 0, 10, 10)};
+
+    const QStringList firstPaths = WallpaperSplitter::splitImage(
+            firstSource, screens, outputDirectory.path());
+    const QStringList repeatedPaths = WallpaperSplitter::splitImage(
+            firstSource, screens, outputDirectory.path());
+    const QStringList secondPaths = WallpaperSplitter::splitImage(
+            secondSource, screens, outputDirectory.path());
+
+    QCOMPARE(firstPaths, repeatedPaths);
+    QCOMPARE(firstPaths.size(), secondPaths.size());
+    for (int index = 0; index < firstPaths.size(); ++index) {
+        QVERIFY(firstPaths.at(index) != secondPaths.at(index));
+        QVERIFY(QFileInfo::exists(firstPaths.at(index)));
+        QVERIFY(QFileInfo::exists(secondPaths.at(index)));
+    }
+}
+
+void SplitImageTest::movesTranslatedLayoutInsideSource() {
+    QImage source(30, 10, QImage::Format_RGB32);
+    source.fill(Qt::black);
+    for (int x = 0; x < 10; ++x) {
+        for (int y = 0; y < source.height(); ++y) {
+            source.setPixelColor(x, y, Qt::red);
+            source.setPixelColor(x + 10, y, Qt::green);
+            source.setPixelColor(x + 20, y, Qt::blue);
+        }
+    }
+
+    QTemporaryDir outputDirectory;
+    QVERIFY(outputDirectory.isValid());
+
+    // The complete layout has the same size as the source but is translated
+    // beyond its bottom-right edge, matching the live 5760x1080 failure.
+    const QList<QRect> translatedScreens{
+            QRect(5, 5, 10, 10),
+            QRect(15, 5, 10, 10),
+            QRect(25, 5, 10, 10),
+    };
+    const QStringList paths = WallpaperSplitter::splitImage(
+            source, translatedScreens, outputDirectory.path());
+
+    QCOMPARE(paths.size(), 3);
+    const QList<QColor> expected{Qt::red, Qt::green, Qt::blue};
+    for (int index = 0; index < paths.size(); ++index) {
+        const QImage crop(paths.at(index));
+        QCOMPARE(crop.size(), QSize(10, 10));
+        QCOMPARE(crop.pixelColor(5, 5), expected.at(index));
+    }
+}
+
+QTEST_MAIN(SplitImageTest)
+#include "splitimage_test.moc"


### PR DESCRIPTION
## Summary

Fix multi-monitor wallpaper generation and assignment on Plasma 6 configurations where Qt and Plasma use different numeric indices for the same physical displays.

This also makes generated filenames inherit the source image name, resolving #13.

## Changes

- Correctly center the virtual screen layout over the source image before calculating crop rectangles.
- Preserve Qt's screen order when generating crops.
- Match crops to Plasma desktops by virtual-desktop geometry instead of assuming Qt and Plasma screen indices are identical.
- Ignore stale Plasma desktop containments with negative screen indices.
- Validate crop rectangles before copying image data.
- Translate an out-of-bounds crop layout back inside the source image as a rigid group when the complete layout still fits.
- Add a content-derived hash to each output path so Plasma reloads the wallpaper when image pixels change.
- Generate readable, flat output filenames using the source basename:

  ```text
  originalfilename-1-<hash>.png
  originalfilename-2-<hash>.png
  ```

- Use the source basename consistently in both GUI and CLI flows.
- Add Qt regression tests for crop ordering, pixel fidelity, content-sensitive paths, filename formatting, and translated layouts.
- Make the Qt Test dependency conditional on `BUILD_TESTING`.

## Background

The original implementation coupled generated crop positions and Plasma assignment to assumptions that do not always hold:

1. Screen rectangles already used virtual-desktop coordinates, but the graphics group was positioned using an additional image-center offset. This could produce incorrect or out-of-bounds crop coordinates.
2. Qt and Plasma can assign different numeric screen indices to the same physical display. Assigning crop `i` directly to Plasma screen `i` could therefore swap wallpapers between displays.
3. Overwriting an image at the same configured path did not reliably cause Plasma to reload changed pixels.

The updated implementation treats crop generation and Plasma assignment separately. Crops are generated from validated geometry, and Plasma desktops are matched to those crops using their virtual-desktop rectangles.

## Testing

Tested with a three-monitor horizontal Plasma 6 layout where Qt reported the displays in physical left-to-right order but Plasma used a different numeric order for the left and middle desktops.

Verified that:

- each generated crop contains the expected pixels;
- each crop is assigned to the correct physical display;
- selecting a different source image updates the configured wallpaper;
- an exactly sized 5760×1080 source no longer fails when the interactive layout has a small translation;
- generated files use the source-derived filename format;
- a Release build with `BUILD_TESTING=ON` succeeds;
- CTest passes all tests;
- a production-style build with `BUILD_TESTING=OFF` succeeds without building the test executable.

Closes #13

